### PR TITLE
Add external DTOs and enums

### DIFF
--- a/example/ExampleApi.fsd
+++ b/example/ExampleApi.fsd
@@ -402,6 +402,9 @@ service ExampleApi
 
 	/// An external data type.
 	externdata ExternalDto;
+
+	/// An external enum.
+	externenum ExternalEnum;
 }
 
 # ExampleApi

--- a/example/ExampleApi.fsd
+++ b/example/ExampleApi.fsd
@@ -399,6 +399,9 @@ service ExampleApi
 		[obsolete(message: "This field was never used.")]
 		oldField: string;
 	}
+
+	/// An external data type.
+	externdata ExternalDto;
 }
 
 # ExampleApi

--- a/example/ExampleApi.fsd
+++ b/example/ExampleApi.fsd
@@ -401,10 +401,10 @@ service ExampleApi
 	}
 
 	/// An external data type.
-	externdata ExternalDto;
+	extern data ExternalDto;
 
 	/// An external enum.
-	externenum ExternalEnum;
+	extern enum ExternalEnum;
 }
 
 # ExampleApi

--- a/example/ExampleApi.fsd.md
+++ b/example/ExampleApi.fsd.md
@@ -463,3 +463,13 @@ data KitchenSink
 	oldField: string;
 }
 ```
+
+```fsd
+/// An external data type.
+extern data ExternalDto;
+```
+
+```fsd
+/// An external enum.
+extern enum ExternalEnum;
+```

--- a/example/output/ExampleApi-nowidgets.fsd
+++ b/example/output/ExampleApi-nowidgets.fsd
@@ -150,6 +150,12 @@ service ExampleApi
 		[obsolete(message: "This field was never used.")]
 		oldField: string;
 	}
+
+	/// An external data type.
+	extern data ExternalDto;
+
+	/// An external enum.
+	extern enum ExternalEnum;
 }
 
 # ExampleApi

--- a/example/output/ExampleApi.fsd
+++ b/example/output/ExampleApi.fsd
@@ -403,10 +403,10 @@ service ExampleApi
 	}
 
 	/// An external data type.
-	externdata ExternalDto;
+	extern data ExternalDto;
 
 	/// An external enum.
-	externenum ExternalEnum;
+	extern enum ExternalEnum;
 }
 
 # ExampleApi

--- a/example/output/ExampleApi.fsd
+++ b/example/output/ExampleApi.fsd
@@ -401,6 +401,9 @@ service ExampleApi
 		[obsolete(message: "This field was never used.")]
 		oldField: string;
 	}
+
+	/// An external data type.
+	externdata ExternalDto;
 }
 
 # ExampleApi

--- a/example/output/ExampleApi.fsd
+++ b/example/output/ExampleApi.fsd
@@ -404,6 +404,9 @@ service ExampleApi
 
 	/// An external data type.
 	externdata ExternalDto;
+
+	/// An external enum.
+	externenum ExternalEnum;
 }
 
 # ExampleApi

--- a/src/Facility.Definition/Fsd/FsdGenerator.cs
+++ b/src/Facility.Definition/Fsd/FsdGenerator.cs
@@ -81,14 +81,6 @@ public sealed class FsdGenerator : CodeGenerator
 						if (enumInfo.Remarks.Count != 0)
 							remarks.AddRange(new[] { "", $"# {enumInfo.Name}", "" }.Concat(enumInfo.Remarks));
 					}
-					else if (member is ServiceExternalDtoInfo externalDto)
-					{
-						WriteSummaryAndAttributes(code, externalDto);
-						code.WriteLine($"extern data {externalDto.Name};");
-
-						if (externalDto.Remarks.Count != 0)
-							remarks.AddRange(new[] { "", $"# {externalDto.Name}", "" }.Concat(externalDto.Remarks));
-					}
 					else if (member is ServiceErrorSetInfo errorSet)
 					{
 						WriteSummaryAndAttributes(code, errorSet);
@@ -98,6 +90,22 @@ public sealed class FsdGenerator : CodeGenerator
 
 						if (errorSet.Remarks.Count != 0)
 							remarks.AddRange(new[] { "", $"# {errorSet.Name}", "" }.Concat(errorSet.Remarks));
+					}
+					else if (member is ServiceExternalDtoInfo externalDto)
+					{
+						WriteSummaryAndAttributes(code, externalDto);
+						code.WriteLine($"extern data {externalDto.Name};");
+
+						if (externalDto.Remarks.Count != 0)
+							remarks.AddRange(new[] { "", $"# {externalDto.Name}", "" }.Concat(externalDto.Remarks));
+					}
+					else if (member is ServiceExternalEnumInfo externalEnum)
+					{
+						WriteSummaryAndAttributes(code, externalEnum);
+						code.WriteLine($"extern enum {externalEnum.Name};");
+
+						if (externalEnum.Remarks.Count != 0)
+							remarks.AddRange(new[] { "", $"# {externalEnum.Name}", "" }.Concat(externalEnum.Remarks));
 					}
 					else
 					{

--- a/src/Facility.Definition/Fsd/FsdGenerator.cs
+++ b/src/Facility.Definition/Fsd/FsdGenerator.cs
@@ -81,6 +81,14 @@ public sealed class FsdGenerator : CodeGenerator
 						if (enumInfo.Remarks.Count != 0)
 							remarks.AddRange(new[] { "", $"# {enumInfo.Name}", "" }.Concat(enumInfo.Remarks));
 					}
+					else if (member is ServiceExternalDtoInfo externalDto)
+					{
+						WriteSummaryAndAttributes(code, externalDto);
+						code.WriteLine($"extern data {externalDto.Name};");
+
+						if (externalDto.Remarks.Count != 0)
+							remarks.AddRange(new[] { "", $"# {externalDto.Name}", "" }.Concat(externalDto.Remarks));
+					}
 					else if (member is ServiceErrorSetInfo errorSet)
 					{
 						WriteSummaryAndAttributes(code, errorSet);

--- a/src/Facility.Definition/Fsd/FsdParsers.cs
+++ b/src/Facility.Definition/Fsd/FsdParsers.cs
@@ -137,6 +137,20 @@ internal static class FsdParsers
 			context.GetPart(ServicePartKind.Keyword, keyword),
 			context.GetPart(ServicePartKind.Name, name));
 
+	private static IParser<ServiceExternalDtoInfo> ExternalDtoParser(Context context) =>
+		from comments1 in CommentOrWhiteSpaceParser.Many()
+		from attributes in AttributeParser(context).Delimited(",").Bracketed("[", "]").Many()
+		from comments2 in CommentOrWhiteSpaceParser.Many()
+		from keyword in KeywordParser("externdata")
+		from name in NameParser.Named("externdata name")
+		from end in PunctuationParser(";")
+		select new ServiceExternalDtoInfo(name.Value,
+			attributes.SelectMany(x => x),
+			BuildSummary(comments1, comments2),
+			context.GetRemarksSection(name.Value)?.Lines,
+			context.GetPart(ServicePartKind.Keyword, keyword),
+			context.GetPart(ServicePartKind.Name, name));
+
 	private static IParser<ServiceMethodInfo> MethodParser(Context context) =>
 		from comments1 in CommentOrWhiteSpaceParser.Many()
 		from attributes in AttributeParser(context).Delimited(",").Bracketed("[", "]").Many()
@@ -154,7 +168,7 @@ internal static class FsdParsers
 			context.GetPart(ServicePartKind.Name, name));
 
 	private static IParser<ServiceMemberInfo> ServiceItemParser(Context context) =>
-		Parser.Or<ServiceMemberInfo>(EnumParser(context), DtoParser(context), MethodParser(context), ErrorSetParser(context));
+		Parser.Or<ServiceMemberInfo>(EnumParser(context), DtoParser(context), ExternalDtoParser(context), MethodParser(context), ErrorSetParser(context));
 
 	private static IParser<ServiceInfo> ServiceParser(Context context) =>
 		from comments1 in CommentOrWhiteSpaceParser.Many()

--- a/src/Facility.Definition/Fsd/FsdParsers.cs
+++ b/src/Facility.Definition/Fsd/FsdParsers.cs
@@ -144,8 +144,8 @@ internal static class FsdParsers
 		from keyword in KeywordParser("extern")
 		from memberInfo in Parser.Or<ServiceMemberInfo>(
 			ExternalDtoParser(context, attributes.SelectMany(x => x), BuildSummary(comments1, comments2)),
-			ExternalEnumParser(context, attributes.SelectMany(x => x), BuildSummary(comments1, comments2))).Once()
-		select memberInfo.Single();
+			ExternalEnumParser(context, attributes.SelectMany(x => x), BuildSummary(comments1, comments2)))
+		select memberInfo;
 
 	private static IParser<ServiceExternalDtoInfo> ExternalDtoParser(Context context, IEnumerable<ServiceAttributeInfo>? attributes, string? summary) =>
 		from keyword in KeywordParser("data")

--- a/src/Facility.Definition/Fsd/FsdParsers.cs
+++ b/src/Facility.Definition/Fsd/FsdParsers.cs
@@ -151,6 +151,20 @@ internal static class FsdParsers
 			context.GetPart(ServicePartKind.Keyword, keyword),
 			context.GetPart(ServicePartKind.Name, name));
 
+	private static IParser<ServiceExternalEnumInfo> ExternalEnumParser(Context context) =>
+		from comments1 in CommentOrWhiteSpaceParser.Many()
+		from attributes in AttributeParser(context).Delimited(",").Bracketed("[", "]").Many()
+		from comments2 in CommentOrWhiteSpaceParser.Many()
+		from keyword in KeywordParser("externenum")
+		from name in NameParser.Named("externenum name")
+		from end in PunctuationParser(";")
+		select new ServiceExternalEnumInfo(name.Value,
+			attributes.SelectMany(x => x),
+			BuildSummary(comments1, comments2),
+			context.GetRemarksSection(name.Value)?.Lines,
+			context.GetPart(ServicePartKind.Keyword, keyword),
+			context.GetPart(ServicePartKind.Name, name));
+
 	private static IParser<ServiceMethodInfo> MethodParser(Context context) =>
 		from comments1 in CommentOrWhiteSpaceParser.Many()
 		from attributes in AttributeParser(context).Delimited(",").Bracketed("[", "]").Many()
@@ -168,7 +182,7 @@ internal static class FsdParsers
 			context.GetPart(ServicePartKind.Name, name));
 
 	private static IParser<ServiceMemberInfo> ServiceItemParser(Context context) =>
-		Parser.Or<ServiceMemberInfo>(EnumParser(context), DtoParser(context), ExternalDtoParser(context), MethodParser(context), ErrorSetParser(context));
+		Parser.Or<ServiceMemberInfo>(EnumParser(context), DtoParser(context), ExternalDtoParser(context), ExternalEnumParser(context), MethodParser(context), ErrorSetParser(context));
 
 	private static IParser<ServiceInfo> ServiceParser(Context context) =>
 		from comments1 in CommentOrWhiteSpaceParser.Many()

--- a/src/Facility.Definition/Http/HttpMethodInfo.cs
+++ b/src/Facility.Definition/Http/HttpMethodInfo.cs
@@ -251,13 +251,13 @@ public sealed class HttpMethodInfo : HttpElementInfo
 		if (fieldTypeKind == ServiceTypeKind.Array)
 			fieldTypeKind = fieldType!.ValueType!.Kind;
 
-		return fieldTypeKind is ServiceTypeKind.String or ServiceTypeKind.Boolean or ServiceTypeKind.Double or ServiceTypeKind.Int32 or ServiceTypeKind.Int64 or ServiceTypeKind.Decimal or ServiceTypeKind.Enum;
+		return fieldTypeKind is ServiceTypeKind.String or ServiceTypeKind.Boolean or ServiceTypeKind.Double or ServiceTypeKind.Int32 or ServiceTypeKind.Int64 or ServiceTypeKind.Decimal or ServiceTypeKind.Enum or ServiceTypeKind.ExternalEnum;
 	}
 
 	private static bool IsValidRequestBodyField(ServiceFieldInfo fieldInfo, ServiceInfo serviceInfo)
 	{
 		var fieldTypeKind = serviceInfo.GetFieldType(fieldInfo)?.Kind;
-		return fieldTypeKind is ServiceTypeKind.Object or ServiceTypeKind.Error or ServiceTypeKind.Dto or ServiceTypeKind.Result or ServiceTypeKind.Array or ServiceTypeKind.Map or ServiceTypeKind.Bytes or ServiceTypeKind.String;
+		return fieldTypeKind is ServiceTypeKind.Object or ServiceTypeKind.Error or ServiceTypeKind.Dto or ServiceTypeKind.Result or ServiceTypeKind.Array or ServiceTypeKind.Map or ServiceTypeKind.Bytes or ServiceTypeKind.String or ServiceTypeKind.ExternalDto;
 	}
 
 	private static bool IsValidResponseBodyField(ServiceFieldInfo fieldInfo, ServiceInfo serviceInfo) =>

--- a/src/Facility.Definition/ServiceExternalDtoInfo.cs
+++ b/src/Facility.Definition/ServiceExternalDtoInfo.cs
@@ -6,7 +6,7 @@ namespace Facility.Definition;
 public sealed class ServiceExternalDtoInfo : ServiceMemberInfo
 {
 	/// <summary>
-	/// Creates a DTO.
+	/// Creates an external DTO.
 	/// </summary>
 	public ServiceExternalDtoInfo(string name, IEnumerable<ServiceAttributeInfo>? attributes = null, string? summary = null, IEnumerable<string>? remarks = null, params ServicePart[] parts)
 		: base(name, attributes, summary, remarks, parts)

--- a/src/Facility.Definition/ServiceExternalDtoInfo.cs
+++ b/src/Facility.Definition/ServiceExternalDtoInfo.cs
@@ -1,0 +1,17 @@
+namespace Facility.Definition;
+
+/// <summary>
+/// An external service DTO.
+/// </summary>
+public sealed class ServiceExternalDtoInfo : ServiceMemberInfo
+{
+	/// <summary>
+	/// Creates a DTO.
+	/// </summary>
+	public ServiceExternalDtoInfo(string name, IEnumerable<ServiceAttributeInfo>? attributes = null, string? summary = null, IEnumerable<string>? remarks = null, params ServicePart[] parts)
+		: base(name, attributes, summary, remarks, parts)
+	{
+	}
+
+	private protected override IEnumerable<ServiceElementInfo> GetExtraChildrenCore() => Array.Empty<ServiceElementInfo>();
+}

--- a/src/Facility.Definition/ServiceExternalEnumInfo.cs
+++ b/src/Facility.Definition/ServiceExternalEnumInfo.cs
@@ -1,0 +1,17 @@
+namespace Facility.Definition;
+
+/// <summary>
+/// An external service enumerated type.
+/// </summary>
+public sealed class ServiceExternalEnumInfo : ServiceMemberInfo
+{
+	/// <summary>
+	/// Creates an external enumerated type.
+	/// </summary>
+	public ServiceExternalEnumInfo(string name, IEnumerable<ServiceAttributeInfo>? attributes = null, string? summary = null, IEnumerable<string>? remarks = null, params ServicePart[] parts)
+		: base(name, attributes, summary, remarks, parts)
+	{
+	}
+
+	private protected override IEnumerable<ServiceElementInfo> GetExtraChildrenCore() => Array.Empty<ServiceElementInfo>();
+}

--- a/src/Facility.Definition/ServiceInfo.cs
+++ b/src/Facility.Definition/ServiceInfo.cs
@@ -16,7 +16,7 @@ public sealed class ServiceInfo : ServiceMemberInfo
 		ValidateName();
 		ValidateNoDuplicateNames(Members, "service member");
 
-		var unsupportedMember = Members.FirstOrDefault(x => !(x is ServiceMethodInfo || x is ServiceDtoInfo || x is ServiceEnumInfo || x is ServiceErrorSetInfo));
+		var unsupportedMember = Members.FirstOrDefault(x => !(x is ServiceMethodInfo || x is ServiceDtoInfo || x is ServiceEnumInfo || x is ServiceErrorSetInfo || x is ServiceExternalDtoInfo));
 		if (unsupportedMember is not null)
 			throw new InvalidOperationException($"Unsupported member type: {unsupportedMember.GetType()}");
 
@@ -66,6 +66,11 @@ public sealed class ServiceInfo : ServiceMemberInfo
 	/// The error sets.
 	/// </summary>
 	public IReadOnlyList<ServiceErrorSetInfo> ErrorSets => Members.OfType<ServiceErrorSetInfo>().ToReadOnlyList();
+
+	/// <summary>
+	/// The external DTOs.
+	/// </summary>
+	public IReadOnlyList<ServiceExternalDtoInfo> ExternalDtos => Members.OfType<ServiceExternalDtoInfo>().ToReadOnlyList();
 
 	/// <summary>
 	/// Finds the member of the specified name.
@@ -152,6 +157,15 @@ public sealed class ServiceInfo : ServiceMemberInfo
 					summary: errorSet.Summary,
 					remarks: errorSet.Remarks,
 					parts: errorSet.GetParts().ToArray());
+			}
+			else if (member is ServiceExternalDtoInfo externalDto)
+			{
+				return new ServiceExternalDtoInfo(
+					name: externalDto.Name,
+					attributes: externalDto.Attributes,
+					summary: externalDto.Summary,
+					remarks: externalDto.Remarks,
+					parts: externalDto.GetParts().ToArray());
 			}
 			else
 			{

--- a/src/Facility.Definition/ServiceInfo.cs
+++ b/src/Facility.Definition/ServiceInfo.cs
@@ -16,7 +16,7 @@ public sealed class ServiceInfo : ServiceMemberInfo
 		ValidateName();
 		ValidateNoDuplicateNames(Members, "service member");
 
-		var unsupportedMember = Members.FirstOrDefault(x => !(x is ServiceMethodInfo || x is ServiceDtoInfo || x is ServiceEnumInfo || x is ServiceErrorSetInfo || x is ServiceExternalDtoInfo));
+		var unsupportedMember = Members.FirstOrDefault(x => !(x is ServiceMethodInfo || x is ServiceDtoInfo || x is ServiceEnumInfo || x is ServiceErrorSetInfo || x is ServiceExternalDtoInfo || x is ServiceExternalEnumInfo));
 		if (unsupportedMember is not null)
 			throw new InvalidOperationException($"Unsupported member type: {unsupportedMember.GetType()}");
 
@@ -71,6 +71,11 @@ public sealed class ServiceInfo : ServiceMemberInfo
 	/// The external DTOs.
 	/// </summary>
 	public IReadOnlyList<ServiceExternalDtoInfo> ExternalDtos => Members.OfType<ServiceExternalDtoInfo>().ToReadOnlyList();
+
+	/// <summary>
+	/// The external enumerated types.
+	/// </summary>
+	public IReadOnlyList<ServiceExternalEnumInfo> ExternalEnums => Members.OfType<ServiceExternalEnumInfo>().ToReadOnlyList();
 
 	/// <summary>
 	/// Finds the member of the specified name.
@@ -166,6 +171,15 @@ public sealed class ServiceInfo : ServiceMemberInfo
 					summary: externalDto.Summary,
 					remarks: externalDto.Remarks,
 					parts: externalDto.GetParts().ToArray());
+			}
+			else if (member is ServiceExternalEnumInfo externalEnum)
+			{
+				return new ServiceExternalEnumInfo(
+					name: externalEnum.Name,
+					attributes: externalEnum.Attributes,
+					summary: externalEnum.Summary,
+					remarks: externalEnum.Remarks,
+					parts: externalEnum.GetParts().ToArray());
 			}
 			else
 			{

--- a/src/Facility.Definition/ServiceInfo.cs
+++ b/src/Facility.Definition/ServiceInfo.cs
@@ -198,6 +198,7 @@ public sealed class ServiceInfo : ServiceMemberInfo
 		switch (type.Kind)
 		{
 			case ServiceTypeKind.Enum:
+			case ServiceTypeKind.ExternalEnum:
 				if (validation.CountRange is not null)
 					attribute.AddValidationError(ServiceDefinitionUtility.CreateInvalidAttributeParameterForTypeError(attribute, type, "count"));
 

--- a/src/Facility.Definition/ServiceTypeInfo.cs
+++ b/src/Facility.Definition/ServiceTypeInfo.cs
@@ -10,7 +10,7 @@ public sealed class ServiceTypeInfo
 	/// </summary>
 	public static ServiceTypeInfo CreatePrimitive(ServiceTypeKind kind)
 	{
-		if (kind is ServiceTypeKind.Dto or ServiceTypeKind.Enum or ServiceTypeKind.Result or ServiceTypeKind.Array or ServiceTypeKind.Map or ServiceTypeKind.Nullable)
+		if (kind is ServiceTypeKind.Dto or ServiceTypeKind.Enum or ServiceTypeKind.ExternalDto or ServiceTypeKind.Result or ServiceTypeKind.Array or ServiceTypeKind.Map or ServiceTypeKind.Nullable)
 			throw new ArgumentOutOfRangeException(nameof(kind), "Kind must be primitive.");
 		return new ServiceTypeInfo(kind);
 	}
@@ -24,6 +24,11 @@ public sealed class ServiceTypeInfo
 	/// Create an enumerated type.
 	/// </summary>
 	public static ServiceTypeInfo CreateEnum(ServiceEnumInfo @enum) => new(ServiceTypeKind.Enum, @enum: @enum);
+
+	/// <summary>
+	/// Create a DTO type.
+	/// </summary>
+	public static ServiceTypeInfo CreateExternalDto(ServiceExternalDtoInfo externalDto) => new(ServiceTypeKind.ExternalDto, externalDto: externalDto);
 
 	/// <summary>
 	/// Create a service result type.
@@ -61,6 +66,11 @@ public sealed class ServiceTypeInfo
 	public ServiceEnumInfo? Enum { get; }
 
 	/// <summary>
+	/// The external DTO (when Kind is ExternalDto).
+	/// </summary>
+	public ServiceExternalDtoInfo? ExternalDto { get; }
+
+	/// <summary>
 	/// The value type (when Kind is Result, Array, or Map).
 	/// </summary>
 	public ServiceTypeInfo? ValueType { get; }
@@ -74,6 +84,7 @@ public sealed class ServiceTypeInfo
 		{
 			ServiceTypeKind.Dto => Dto!.Name,
 			ServiceTypeKind.Enum => Enum!.Name,
+			ServiceTypeKind.ExternalDto => ExternalDto!.Name,
 			ServiceTypeKind.Result => $"result<{ValueType}>",
 			ServiceTypeKind.Array => $"{ValueType}[]",
 			ServiceTypeKind.Map => $"map<{ValueType}>",
@@ -127,16 +138,20 @@ public sealed class ServiceTypeInfo
 
 			if (member is ServiceEnumInfo @enum)
 				return CreateEnum(@enum);
+
+			if (member is ServiceExternalDtoInfo externalDto)
+				return CreateExternalDto(externalDto);
 		}
 
 		return null;
 	}
 
-	private ServiceTypeInfo(ServiceTypeKind kind, ServiceDtoInfo? dto = null, ServiceEnumInfo? @enum = null, ServiceTypeInfo? valueType = null)
+	private ServiceTypeInfo(ServiceTypeKind kind, ServiceDtoInfo? dto = null, ServiceEnumInfo? @enum = null, ServiceExternalDtoInfo? externalDto = null, ServiceTypeInfo? valueType = null)
 	{
 		Kind = kind;
 		Dto = dto;
 		Enum = @enum;
+		ExternalDto = externalDto;
 		ValueType = valueType;
 	}
 

--- a/src/Facility.Definition/ServiceTypeInfo.cs
+++ b/src/Facility.Definition/ServiceTypeInfo.cs
@@ -10,7 +10,7 @@ public sealed class ServiceTypeInfo
 	/// </summary>
 	public static ServiceTypeInfo CreatePrimitive(ServiceTypeKind kind)
 	{
-		if (kind is ServiceTypeKind.Dto or ServiceTypeKind.Enum or ServiceTypeKind.ExternalDto or ServiceTypeKind.Result or ServiceTypeKind.Array or ServiceTypeKind.Map or ServiceTypeKind.Nullable)
+		if (kind is ServiceTypeKind.Dto or ServiceTypeKind.Enum or ServiceTypeKind.ExternalDto or ServiceTypeKind.ExternalEnum or ServiceTypeKind.Result or ServiceTypeKind.Array or ServiceTypeKind.Map or ServiceTypeKind.Nullable)
 			throw new ArgumentOutOfRangeException(nameof(kind), "Kind must be primitive.");
 		return new ServiceTypeInfo(kind);
 	}
@@ -26,9 +26,14 @@ public sealed class ServiceTypeInfo
 	public static ServiceTypeInfo CreateEnum(ServiceEnumInfo @enum) => new(ServiceTypeKind.Enum, @enum: @enum);
 
 	/// <summary>
-	/// Create a DTO type.
+	/// Create an external DTO type.
 	/// </summary>
 	public static ServiceTypeInfo CreateExternalDto(ServiceExternalDtoInfo externalDto) => new(ServiceTypeKind.ExternalDto, externalDto: externalDto);
+
+	/// <summary>
+	/// Create an external enumerated type.
+	/// </summary>
+	public static ServiceTypeInfo CreateExternalEnum(ServiceExternalEnumInfo externalEnum) => new(ServiceTypeKind.ExternalEnum, externalEnum: externalEnum);
 
 	/// <summary>
 	/// Create a service result type.
@@ -71,6 +76,11 @@ public sealed class ServiceTypeInfo
 	public ServiceExternalDtoInfo? ExternalDto { get; }
 
 	/// <summary>
+	/// The external enumerated type (when Kind is ExternalEnum).
+	/// </summary>
+	public ServiceExternalEnumInfo? ExternalEnum { get; }
+
+	/// <summary>
 	/// The value type (when Kind is Result, Array, or Map).
 	/// </summary>
 	public ServiceTypeInfo? ValueType { get; }
@@ -85,6 +95,7 @@ public sealed class ServiceTypeInfo
 			ServiceTypeKind.Dto => Dto!.Name,
 			ServiceTypeKind.Enum => Enum!.Name,
 			ServiceTypeKind.ExternalDto => ExternalDto!.Name,
+			ServiceTypeKind.ExternalEnum => ExternalEnum!.Name,
 			ServiceTypeKind.Result => $"result<{ValueType}>",
 			ServiceTypeKind.Array => $"{ValueType}[]",
 			ServiceTypeKind.Map => $"map<{ValueType}>",
@@ -141,17 +152,21 @@ public sealed class ServiceTypeInfo
 
 			if (member is ServiceExternalDtoInfo externalDto)
 				return CreateExternalDto(externalDto);
+
+			if (member is ServiceExternalEnumInfo externalEnum)
+				return CreateExternalEnum(externalEnum);
 		}
 
 		return null;
 	}
 
-	private ServiceTypeInfo(ServiceTypeKind kind, ServiceDtoInfo? dto = null, ServiceEnumInfo? @enum = null, ServiceExternalDtoInfo? externalDto = null, ServiceTypeInfo? valueType = null)
+	private ServiceTypeInfo(ServiceTypeKind kind, ServiceDtoInfo? dto = null, ServiceEnumInfo? @enum = null, ServiceExternalDtoInfo? externalDto = null, ServiceExternalEnumInfo? externalEnum = null, ServiceTypeInfo? valueType = null)
 	{
 		Kind = kind;
 		Dto = dto;
 		Enum = @enum;
 		ExternalDto = externalDto;
+		ExternalEnum = externalEnum;
 		ValueType = valueType;
 	}
 

--- a/src/Facility.Definition/ServiceTypeKind.cs
+++ b/src/Facility.Definition/ServiceTypeKind.cs
@@ -66,6 +66,11 @@ public enum ServiceTypeKind
 	ExternalDto,
 
 	/// <summary>
+	/// An external enumerated type.
+	/// </summary>
+	ExternalEnum,
+
+	/// <summary>
 	/// A service result.
 	/// </summary>
 	Result,

--- a/src/Facility.Definition/ServiceTypeKind.cs
+++ b/src/Facility.Definition/ServiceTypeKind.cs
@@ -61,6 +61,11 @@ public enum ServiceTypeKind
 	Enum,
 
 	/// <summary>
+	/// An external DTO.
+	/// </summary>
+	ExternalDto,
+
+	/// <summary>
 	/// A service result.
 	/// </summary>
 	Result,

--- a/src/Facility.Definition/ServiceTypeKind.cs
+++ b/src/Facility.Definition/ServiceTypeKind.cs
@@ -61,16 +61,6 @@ public enum ServiceTypeKind
 	Enum,
 
 	/// <summary>
-	/// An external DTO.
-	/// </summary>
-	ExternalDto,
-
-	/// <summary>
-	/// An external enumerated type.
-	/// </summary>
-	ExternalEnum,
-
-	/// <summary>
 	/// A service result.
 	/// </summary>
 	Result,
@@ -89,4 +79,14 @@ public enum ServiceTypeKind
 	/// A nullable.
 	/// </summary>
 	Nullable,
+
+	/// <summary>
+	/// An external DTO.
+	/// </summary>
+	ExternalDto,
+
+	/// <summary>
+	/// An external enumerated type.
+	/// </summary>
+	ExternalEnum,
 }

--- a/tests/Facility.Definition.UnitTests/ServiceTests.cs
+++ b/tests/Facility.Definition.UnitTests/ServiceTests.cs
@@ -75,7 +75,7 @@ public sealed class ServiceTests
 	[Test]
 	public void MissingEndBrace()
 	{
-		TestUtility.ParseInvalidTestApi("service TestApi {").Message.Should().Be("TestApi.fsd(1,18): expected '}' or '[' or 'data' or 'enum' or 'errors' or 'method'");
+		TestUtility.ParseInvalidTestApi("service TestApi {").Message.Should().Be("TestApi.fsd(1,18): expected '}' or '[' or 'data' or 'enum' or 'errors' or 'externdata' or 'method'");
 	}
 
 	[Test]
@@ -103,6 +103,13 @@ public sealed class ServiceTests
 	{
 		TestUtility.ParseInvalidTestApi("service TestApi { enum xyzzy { x } enum xyzzy { x } }")
 			.Message.Should().Be("TestApi.fsd(1,36): Duplicate service member: xyzzy");
+	}
+
+	[Test]
+	public void DuplicateExternalDto()
+	{
+		TestUtility.ParseInvalidTestApi("service TestApi { externdata xyzzy; externdata xyzzy; }")
+			.Message.Should().Be("TestApi.fsd(1,37): Duplicate service member: xyzzy");
 	}
 
 	[Test]

--- a/tests/Facility.Definition.UnitTests/ServiceTests.cs
+++ b/tests/Facility.Definition.UnitTests/ServiceTests.cs
@@ -75,7 +75,13 @@ public sealed class ServiceTests
 	[Test]
 	public void MissingEndBrace()
 	{
-		TestUtility.ParseInvalidTestApi("service TestApi {").Message.Should().Be("TestApi.fsd(1,18): expected '}' or '[' or 'data' or 'enum' or 'errors' or 'externdata' or 'externenum' or 'method'");
+		TestUtility.ParseInvalidTestApi("service TestApi {").Message.Should().Be("TestApi.fsd(1,18): expected '}' or '[' or 'data' or 'enum' or 'errors' or 'extern' or 'method'");
+	}
+
+	[Test]
+	public void MissingExternType()
+	{
+		TestUtility.ParseInvalidTestApi("service TestApi { extern xyz; }").Message.Should().Be("TestApi.fsd(1,26): expected 'data' or 'enum'");
 	}
 
 	[Test]
@@ -108,15 +114,15 @@ public sealed class ServiceTests
 	[Test]
 	public void DuplicateExternalDto()
 	{
-		TestUtility.ParseInvalidTestApi("service TestApi { externdata xyzzy; externdata xyzzy; }")
-			.Message.Should().Be("TestApi.fsd(1,37): Duplicate service member: xyzzy");
+		TestUtility.ParseInvalidTestApi("service TestApi { extern data xyzzy; extern data xyzzy; }")
+			.Message.Should().Be("TestApi.fsd(1,45): Duplicate service member: xyzzy");
 	}
 
 	[Test]
 	public void DuplicateExternalEnum()
 	{
-		TestUtility.ParseInvalidTestApi("service TestApi { externenum xyzzy; externenum xyzzy; }")
-			.Message.Should().Be("TestApi.fsd(1,37): Duplicate service member: xyzzy");
+		TestUtility.ParseInvalidTestApi("service TestApi { extern enum xyzzy; extern enum xyzzy; }")
+			.Message.Should().Be("TestApi.fsd(1,45): Duplicate service member: xyzzy");
 	}
 
 	[Test]

--- a/tests/Facility.Definition.UnitTests/ServiceTests.cs
+++ b/tests/Facility.Definition.UnitTests/ServiceTests.cs
@@ -75,7 +75,7 @@ public sealed class ServiceTests
 	[Test]
 	public void MissingEndBrace()
 	{
-		TestUtility.ParseInvalidTestApi("service TestApi {").Message.Should().Be("TestApi.fsd(1,18): expected '}' or '[' or 'data' or 'enum' or 'errors' or 'externdata' or 'method'");
+		TestUtility.ParseInvalidTestApi("service TestApi {").Message.Should().Be("TestApi.fsd(1,18): expected '}' or '[' or 'data' or 'enum' or 'errors' or 'externdata' or 'externenum' or 'method'");
 	}
 
 	[Test]
@@ -109,6 +109,13 @@ public sealed class ServiceTests
 	public void DuplicateExternalDto()
 	{
 		TestUtility.ParseInvalidTestApi("service TestApi { externdata xyzzy; externdata xyzzy; }")
+			.Message.Should().Be("TestApi.fsd(1,37): Duplicate service member: xyzzy");
+	}
+
+	[Test]
+	public void DuplicateExternalEnum()
+	{
+		TestUtility.ParseInvalidTestApi("service TestApi { externenum xyzzy; externenum xyzzy; }")
 			.Message.Should().Be("TestApi.fsd(1,37): Duplicate service member: xyzzy");
 	}
 

--- a/tests/Facility.Definition.UnitTests/ServiceTypeInfoTests.cs
+++ b/tests/Facility.Definition.UnitTests/ServiceTypeInfoTests.cs
@@ -21,6 +21,7 @@ public class ServiceTypeInfoTests
 		type.Kind.Should().Be(kind);
 		type.Dto.Should().BeNull();
 		type.Enum.Should().BeNull();
+		type.ExternalDto.Should().BeNull();
 		type.ValueType.Should().BeNull();
 		type.ToString().Should().Be(name);
 	}
@@ -34,6 +35,7 @@ public class ServiceTypeInfoTests
 		type.Kind.Should().Be(ServiceTypeKind.Dto);
 		type.Dto.Should().Be(service.Dtos[0]);
 		type.Enum.Should().BeNull();
+		type.ExternalDto.Should().BeNull();
 		type.ValueType.Should().BeNull();
 		type.ToString().Should().Be("MyDto");
 	}
@@ -47,8 +49,23 @@ public class ServiceTypeInfoTests
 		type.Kind.Should().Be(ServiceTypeKind.Enum);
 		type.Dto.Should().BeNull();
 		type.Enum.Should().Be(service.Enums[0]);
+		type.ExternalDto.Should().BeNull();
 		type.ValueType.Should().BeNull();
 		type.ToString().Should().Be("MyEnum");
+	}
+
+	[Test]
+	public void ExternalDtoType()
+	{
+		var service = new ServiceInfo(name: "MyApi",
+			members: new ServiceMemberInfo[] { new ServiceMethodInfo("myMethod", requestFields: new[] { new ServiceFieldInfo("myField", "MyExternalDto") }), new ServiceExternalDtoInfo("MyExternalDto") });
+		var type = service.GetFieldType(service.Methods[0].RequestFields[0])!;
+		type.Kind.Should().Be(ServiceTypeKind.ExternalDto);
+		type.Dto.Should().BeNull();
+		type.Enum.Should().BeNull();
+		type.ExternalDto.Should().Be(service.ExternalDtos[0]);
+		type.ValueType.Should().BeNull();
+		type.ToString().Should().Be("MyExternalDto");
 	}
 
 	[TestCase("result<MyDto>", ServiceTypeKind.Result)]
@@ -64,6 +81,23 @@ public class ServiceTypeInfoTests
 		type.Dto.Should().BeNull();
 		type.Enum.Should().BeNull();
 		type.ValueType!.Dto.Should().Be(service.Dtos[0]);
+		type.ToString().Should().Be(name);
+	}
+
+	[TestCase("result<MyExternalDto>", ServiceTypeKind.Result)]
+	[TestCase("MyExternalDto[]", ServiceTypeKind.Array)]
+	[TestCase("map<MyExternalDto>", ServiceTypeKind.Map)]
+	[TestCase("nullable<MyExternalDto>", ServiceTypeKind.Nullable)]
+	public void ContainerOfExternalDtoType(string name, ServiceTypeKind kind)
+	{
+		var service = new ServiceInfo(name: "MyApi",
+			members: new ServiceMemberInfo[] { new ServiceMethodInfo("myMethod", requestFields: new[] { new ServiceFieldInfo("myField", name) }), new ServiceExternalDtoInfo("MyExternalDto") });
+		var type = service.GetFieldType(service.Methods[0].RequestFields[0])!;
+		type.Kind.Should().Be(kind);
+		type.Dto.Should().BeNull();
+		type.Enum.Should().BeNull();
+		type.ExternalDto.Should().BeNull();
+		type.ValueType!.ExternalDto.Should().Be(service.ExternalDtos[0]);
 		type.ToString().Should().Be(name);
 	}
 }

--- a/tests/Facility.Definition.UnitTests/ServiceTypeInfoTests.cs
+++ b/tests/Facility.Definition.UnitTests/ServiceTypeInfoTests.cs
@@ -22,6 +22,7 @@ public class ServiceTypeInfoTests
 		type.Dto.Should().BeNull();
 		type.Enum.Should().BeNull();
 		type.ExternalDto.Should().BeNull();
+		type.ExternalEnum.Should().BeNull();
 		type.ValueType.Should().BeNull();
 		type.ToString().Should().Be(name);
 	}
@@ -36,6 +37,7 @@ public class ServiceTypeInfoTests
 		type.Dto.Should().Be(service.Dtos[0]);
 		type.Enum.Should().BeNull();
 		type.ExternalDto.Should().BeNull();
+		type.ExternalEnum.Should().BeNull();
 		type.ValueType.Should().BeNull();
 		type.ToString().Should().Be("MyDto");
 	}
@@ -50,6 +52,7 @@ public class ServiceTypeInfoTests
 		type.Dto.Should().BeNull();
 		type.Enum.Should().Be(service.Enums[0]);
 		type.ExternalDto.Should().BeNull();
+		type.ExternalEnum.Should().BeNull();
 		type.ValueType.Should().BeNull();
 		type.ToString().Should().Be("MyEnum");
 	}
@@ -64,8 +67,24 @@ public class ServiceTypeInfoTests
 		type.Dto.Should().BeNull();
 		type.Enum.Should().BeNull();
 		type.ExternalDto.Should().Be(service.ExternalDtos[0]);
+		type.ExternalEnum.Should().BeNull();
 		type.ValueType.Should().BeNull();
 		type.ToString().Should().Be("MyExternalDto");
+	}
+
+	[Test]
+	public void ExternalEnumType()
+	{
+		var service = new ServiceInfo(name: "MyApi",
+			members: new ServiceMemberInfo[] { new ServiceMethodInfo("myMethod", requestFields: new[] { new ServiceFieldInfo("myField", "MyExternalEnum") }), new ServiceExternalEnumInfo("MyExternalEnum") });
+		var type = service.GetFieldType(service.Methods[0].RequestFields[0])!;
+		type.Kind.Should().Be(ServiceTypeKind.ExternalEnum);
+		type.Dto.Should().BeNull();
+		type.Enum.Should().BeNull();
+		type.ExternalDto.Should().BeNull();
+		type.ExternalEnum.Should().Be(service.ExternalEnums[0]);
+		type.ValueType.Should().BeNull();
+		type.ToString().Should().Be("MyExternalEnum");
 	}
 
 	[TestCase("result<MyDto>", ServiceTypeKind.Result)]
@@ -80,6 +99,8 @@ public class ServiceTypeInfoTests
 		type.Kind.Should().Be(kind);
 		type.Dto.Should().BeNull();
 		type.Enum.Should().BeNull();
+		type.ExternalDto.Should().BeNull();
+		type.ExternalEnum.Should().BeNull();
 		type.ValueType!.Dto.Should().Be(service.Dtos[0]);
 		type.ToString().Should().Be(name);
 	}
@@ -97,6 +118,7 @@ public class ServiceTypeInfoTests
 		type.Dto.Should().BeNull();
 		type.Enum.Should().BeNull();
 		type.ExternalDto.Should().BeNull();
+		type.ExternalEnum.Should().BeNull();
 		type.ValueType!.ExternalDto.Should().Be(service.ExternalDtos[0]);
 		type.ToString().Should().Be(name);
 	}

--- a/tests/Facility.Definition.UnitTests/ValidationTests.cs
+++ b/tests/Facility.Definition.UnitTests/ValidationTests.cs
@@ -261,7 +261,7 @@ public sealed class ValidationTests
 			  {
 			    X
 			  }
-			
+
 			  method do
 			  {
 			    [validate(regex: "\\d+.{2}")]
@@ -281,7 +281,7 @@ public sealed class ValidationTests
 			  {
 			    X
 			  }
-			
+
 			  method do
 			  {
 			    [validate(count: -1..10)]
@@ -357,5 +357,23 @@ public sealed class ValidationTests
 		var range = service.Methods.Single().RequestFields.Single().Validation!.CountRange!;
 		range.Minimum.Should().Be(10);
 		range.Maximum.Should().Be(10);
+	}
+
+	[Test]
+	public void ExternEnum_CanHaveValidation()
+	{
+		var service = TestUtility.ParseTestApi("""
+			service TestApi {
+				[csharp(name: "ExternalEnum", namespace: "Facility.Definition.UnitTests.ValidationTests")]
+				extern enum ExternalEnum;
+
+				method do
+				{
+					[validate]
+					one: ExternalEnum;
+				}: {}
+			}
+			""");
+		service.Methods.Single().RequestFields.Single().Validation.Should().NotBeNull();
 	}
 }


### PR DESCRIPTION
An idea as an alternative to supporting an [import mechansim](https://github.com/FacilityApi/Facility/issues/35). Want to get some feedback to see if this is a good idea or not.

See https://github.com/FacilityApi/FacilityCSharp/pull/80 for related C# generator PR.

# Concept

This would add support for external DTOs and enums within an FSD file. In my mind, it's sort of like a C `extern`. Facility does not resolve the type when generating source files. It trusts that what you put in as an extern type will exist. It's up to the project to ensure the specified types exist at build time.

Consider this FSD snippet:

```
[csharp(type: "FilterDto", namespace: Some.Project.Api.v1.Client)]
[js(type: "IFilter", module: "@example/some-project-api")
extern data Filter;

[csharp(type: "AppFamily", namespace: Some.Project.Api.v1.Client)]
[js(type: "AppFamily", module: "@example/some-project-api")]
extern enum AppFamily;

data Foo {
    id: int32;
    filter: Filter;
    appFamily: AppFamily;
}
```

The attributes on the external type instruct the code generators on where the type is defined.

For this example, the C# generator would produce a `FooDto` class like:

```
namespace Some.Project.Bff
{
	[System.CodeDom.Compiler.GeneratedCode("fsdgencsharp", "")]
	public sealed partial class FooDto : ServiceDto<FooDto>
	{
		/// <summary>
		/// Creates an instance.
		/// </summary>
		public FooDto()
		{
		}

		public int? Id { get; set; }

		public Some.Project.Api.v1.Client.FilterDto? Filter { get; set; }

		public Some.Project.Api.v1.Client.AppFamily? AppFamily { get; set; }

		/// <summary>
		/// Returns the DTO as JSON.
		/// </summary>
		public override string ToString() => SystemTextJsonServiceSerializer.Instance.ToJson(this);

		/// <summary>
		/// Determines if two DTOs are equivalent.
		/// </summary>
		public override bool IsEquivalentTo(FooDto? other)
		{
			return other != null &&
				Id == other.Id &&
				ServiceDataUtility.AreEquivalentDtos(Filter, other.Filter) &&
				AppFamily == other.AppFamily;
		}
	}
}
```

Typescript generator output:

```
import { AppFamily, IFilter } from "@example/some-project-api"

export interface IFoo {
    id: number;
    filter: IFilter;
    appFamily: AppFamily;
}
```

For TypeScript an optional alias could be provided in the FSD attribute:

```
[js(type: "IFilter", alias: "ISomeApiFilter", module: "@example/some-project-api")]
```

Which would result in:

```
import { AppFamily, IFilter as ISomeApiFilter } from "@example/some-project-api"

export interface IFoo {
    id: number;
    filter: ISomeApiFilter;
    appFamily: AppFamily;
}
```

# Rationale

There are two cases where this would be helpful. First, when splitting an API into two FSD services (one for user-land and one for admin-land API clients), it is helpful to share certain type definitions/enumerations rather than redefining in both FSD files.

Second, when an FSD is used to generate a BFF client. It's often useful to pass certain types through from an API to the BFF instead of redefining and mapping those types. A BFF may aggregate data from multiple services and pass the data through to the frontend. Many times the data is transformed and will need mapped anyway, but sometimes certain types are simply passed through. This is often the case with enumerations.

# Concerns

I don't know if defining external types will be burdensome if there begin to be a lot of them. This may not be as nice as an FSD import mechanism. It seems simpler, but not sure if it's something desired to include in Facility or not.