### PR TITLE
Support [http(from: custom)] on request/response fields.

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
 
   <PropertyGroup>
-    <VersionPrefix>2.11.0</VersionPrefix>
+    <VersionPrefix>2.12.0</VersionPrefix>
     <PackageValidationBaselineVersion>2.10.1</PackageValidationBaselineVersion>
     <LangVersion>12.0</LangVersion>
     <Nullable>enable</Nullable>

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,5 +1,9 @@
 # Release Notes
 
+## 2.12.0
+
+* Support `[http(from: custom)]` on request/response fields.
+
 ## 2.11.0
 
 * Add support for `datetime`.

--- a/src/Facility.Definition/Http/HttpMethodInfo.cs
+++ b/src/Facility.Definition/Http/HttpMethodInfo.cs
@@ -146,6 +146,9 @@ public sealed class HttpMethodInfo : HttpElementInfo
 					AddValidationError(new ServiceDefinitionError("Type not supported by header request field.", requestField.Position));
 				requestHeaderFields.Add(new HttpHeaderFieldInfo(requestField));
 			}
+			else if (from == "custom")
+			{
+			}
 			else if (from is not null)
 			{
 				AddValidationError(new ServiceDefinitionError($"Unsupported 'from' parameter of 'http' attribute: '{from}'", requestField.Position));
@@ -206,6 +209,9 @@ public sealed class HttpMethodInfo : HttpElementInfo
 
 				case "normal" or null:
 					responseNormalFields.Add(new HttpNormalFieldInfo(responseField));
+					break;
+
+				case "custom":
 					break;
 
 				default:

--- a/tests/Facility.Definition.UnitTests/Http/HttpMethodInfoTests.cs
+++ b/tests/Facility.Definition.UnitTests/Http/HttpMethodInfoTests.cs
@@ -561,6 +561,20 @@ public class HttpMethodInfoTests : HttpInfoTestsBase
 	}
 
 	[Test]
+	public void RequestFieldCustomFrom()
+	{
+		var method = ParseHttpApi("service TestApi { method do { [http(from: custom)] xyzzy: string; }: {} }").Methods.Single();
+		method.RequestNormalFields.Should().BeEmpty();
+	}
+
+	[Test]
+	public void ResponseFieldCustomFrom()
+	{
+		var method = ParseHttpApi("service TestApi { method do {}: { [http(from: custom)] xyzzy: string; } }").Methods.Single();
+		method.ValidResponses.Single().NormalFields.Should().BeEmpty();
+	}
+
+	[Test]
 	public void RequestHeaderFieldBadParameter()
 	{
 		ParseInvalidHttpApi("service TestApi { method do { [http(from: header, nam: x)] xyzzy: string; }: {} }")


### PR DESCRIPTION
These fields are ignored by the HTTP mapping.